### PR TITLE
Feature: Add `Router` Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 # readme in the source folder, only used for npm.
 source/README.md
 
+# test as server
+function/server.js
+
 # functions
 **/code.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,5 @@
 # readme in the source folder, only used for npm.
 source/README.md
 
-# test as server
-function/server.js
-
 # functions
 **/code.tar.gz

--- a/source/.github/workflows/ci.yaml
+++ b/source/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch: # for manual runs
+  pull_request:
+    types: [ opened, synchronize ]
+
+jobs:
+  build-and-test:
+    name: Run Lint and Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Run Prettier
+        run: npm run lint
+
+      - name: Run Tests
+        run: npm run tests

--- a/source/.github/workflows/ci.yaml
+++ b/source/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   workflow_dispatch: # for manual runs
   pull_request:
-    types: [ opened, synchronize ]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   build-and-test:

--- a/source/.npmignore
+++ b/source/.npmignore
@@ -1,0 +1,2 @@
+tests
+.prettierignore

--- a/source/.npmignore
+++ b/source/.npmignore
@@ -1,2 +1,3 @@
 tests
+.github
 .prettierignore

--- a/source/.prettierignore
+++ b/source/.prettierignore
@@ -1,2 +1,3 @@
 *.json
 README.md
+**/*.yaml

--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -367,7 +367,18 @@ class AppExpress {
             // clear the dependencies.
             this.#clearDependencies(context);
 
-            return routeHandlerResult;
+            if (routeHandlerResult) return routeHandlerResult;
+            else if (context.res.dynamic) return context.res.dynamic;
+            else {
+                // for console executions.
+                context.error(
+                    'Invalid return from route. Use `response.empty()` for no expected response.',
+                );
+
+                // return as per original implementation,
+                // open-runtimes > node* > src > server.js
+                return response.send('', 500);
+            }
         } else {
             // mimic express.js and return a similar error.
             const errorMessage = `Cannot ${request.method.toUpperCase()} '${request.path}'.`;

--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -97,7 +97,7 @@ class AppExpress {
     };
 
     constructor() {
-        /** @type {Array<(req: AppExpressRequest, res: AppExpressResponse, log: function(string) : void, error: function(string): void) => Promise<void>>} */
+        /** @type {Array<MiddlewareHandler>} */
         this._middlewares = [];
 
         /** @type {Array<{type: Function, id: string, instance: any}>} */
@@ -113,21 +113,23 @@ class AppExpress {
     /**
      * Register a custom middleware.
      *
-     * @param {RequestHandler} middleware - The middleware function to add to the chain.
+     * @param {MiddlewareHandler} middleware - The middleware/request handler to add to the chain.
      *
      * @example
      * ```javascript
-     * appExpress.middleware((request, response, log, error) => {
+     * appExpress.middleware((request, log, error) => {
      *      // do something with `request` object.
      *
      *     log('this is a debug log');
      *     error('this is an error log');
+     *
+     *     // throw an Error here to exit the middleware chain.
      * });
      * ```
      *
      * @example
      * ```javascript
-     * const loggingMiddleware = (request, response, log, error) => {
+     * const loggingMiddleware = (request, log, error) => {
      *     // do something with `request` object.
      *
      *     log('this is a debug log');
@@ -345,12 +347,7 @@ class AppExpress {
             // execute the middlewares.
             if (this._middlewares.length > 0) {
                 for (const middleware of this._middlewares) {
-                    await middleware(
-                        request,
-                        response,
-                        context.log,
-                        context.error,
-                    );
+                    await middleware(request, context.log, context.error);
                 }
             } else {
                 // ignore, no middlewares.

--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -365,11 +365,15 @@ class AppExpress {
             this.#clearDependencies(context);
 
             if (routeHandlerResult) return routeHandlerResult;
-            else if (context.res.dynamic) return context.res.dynamic;
-            else {
+            else if (
+                context.res.dynamic !== null &&
+                context.res.dynamic !== undefined
+            ) {
+                return context.res.dynamic; // allow `response.empty()`
+            } else {
                 // for console executions.
                 context.error(
-                    'Invalid return from route. Use `response.empty()` for no expected response.',
+                    `Invalid return from route ${request.path}. Use 'response.empty()' if no response is expected.`,
                 );
 
                 // return as per original implementation,

--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -100,8 +100,8 @@ class AppExpress {
         /** @type {Array<MiddlewareHandler>} */
         this._middlewares = [];
 
-        /** @type {Array<{type: Function, id: string, instance: any}>} */
-        this._dependencies = [];
+        /** @type {InjectionRegistry} */
+        this._dependencies = new Map();
 
         /** @type string */
         this._viewsDirectory = '';
@@ -243,28 +243,23 @@ class AppExpress {
      * @throws {Error} - If an instance already exists.
      */
     inject(object, identifier = '') {
-        const type = object.constructor;
-        const key = identifier ? `${type.name}:${identifier}` : type.name;
-        const exists = this._dependencies.some(
-            (injection) =>
-                (injection.id
-                    ? `${injection.type.name}:${injection.id}`
-                    : injection.type.name) === key,
-        );
+        const objectType = object.constructor;
+        const objectName = objectType.name;
+        const key = identifier ? `${objectName}:${identifier}` : objectName;
 
-        if (exists) {
+        if (this._dependencies.has(key)) {
             if (identifier) {
                 throw new Error(
-                    `An instance of '${type.name}' with identifier '${identifier}' is already injected.`,
+                    `An instance of '${objectName}' with identifier '${identifier}' is already injected.`,
                 );
             } else {
                 throw new Error(
-                    `An instance of '${type.name}' is already injected.`,
+                    `An instance of '${objectName}' is already injected.`,
                 );
             }
         }
 
-        this._dependencies.push({ type, id: identifier, instance: object });
+        this._dependencies.set(key, { type: objectType, instance: object });
     }
 
     /**

--- a/source/package.json
+++ b/source/package.json
@@ -13,6 +13,7 @@
     "tabWidth": 4,
     "singleQuote": true
   },
+  "homepage": "https://github.com/itznotabug/appexpress",
   "repository": {
     "type": "git",
     "url": "https://github.com/itznotabug/appexpress.git"

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itznotabug/appexpress",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "An `express.js` like framework for Appwrite Functions, enabling super-easy navigation!",
   "author": "@itznotabug",
   "type": "module",

--- a/source/package.json
+++ b/source/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {
+    "tests": "node tests/test.js",
     "lint": "prettier . --check",
     "format": "prettier . --write"
   },

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itznotabug/appexpress",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "An `express.js` like framework for Appwrite Functions, enabling super-easy navigation!",
   "author": "@itznotabug",
   "type": "module",

--- a/source/package.json
+++ b/source/package.json
@@ -4,6 +4,7 @@
   "description": "An `express.js` like framework for Appwrite Functions, enabling super-easy navigation!",
   "author": "@itznotabug",
   "type": "module",
+  "main": "appexpress.js",
   "license": "Apache-2.0",
   "scripts": {
     "tests": "node tests/test.js",

--- a/source/tests/entrypoint/index.js
+++ b/source/tests/entrypoint/index.js
@@ -1,6 +1,9 @@
 import * as crypto from 'node:crypto';
 import AppExpress from '../../appexpress.js';
 
+/**
+ * Sample repository for `DI`.
+ */
 class LoremIpsumRepository {
     constructor() {
         this._loremIpsum =
@@ -27,6 +30,19 @@ express.middleware((request) => {
 
     if (isConsole && !userJwtToken) {
         throw Error('No JWT Token found, aborting the requests.');
+    }
+});
+
+// middleware for direct return
+express.middleware((request, response) => {
+    const isFavIconPath =
+        request.method === 'get' && request.path.includes('assets');
+    if (isFavIconPath) {
+        const { mode } = request.query;
+        response.send(
+            `we don't really have a ${mode ? 'dark ' : ''}favicon yet, sorry`,
+            404,
+        );
     }
 });
 
@@ -78,6 +94,17 @@ injectionRouter.get('/error', (request, response) => {
 });
 
 express.use('/lorem_ipsum', injectionRouter);
+
+// return custom headers
+const headersRouter = new AppExpress.Router();
+headersRouter.get('/:uuid', (request, response) => {
+    const { uuid } = request.params;
+    response.setHeaders({ 'custom-header': uuid });
+    response.send(uuid);
+});
+
+headersRouter.get('/clear', (_, response) => response.send('cleared'));
+express.use('/headers', headersRouter);
 
 // Appwrite Function Entrypoint!
 export default async (context) => await express.attach(context);

--- a/source/tests/entrypoint/index.js
+++ b/source/tests/entrypoint/index.js
@@ -1,0 +1,83 @@
+import * as crypto from 'node:crypto';
+import AppExpress from '../../appexpress.js';
+
+class LoremIpsumRepository {
+    constructor() {
+        this._loremIpsum =
+            'Lorem Ipsum is simply dummy text of the printing and typesetting industry.';
+    }
+
+    get = () => this._loremIpsum;
+}
+
+const express = new AppExpress();
+const router = new AppExpress.Router();
+const repositoryOne = new LoremIpsumRepository();
+const repositoryTwo = new LoremIpsumRepository();
+
+// inject for later usage
+express.inject(repositoryOne, 'one');
+// random identifier so we cannot take a guess
+express.inject(repositoryTwo, crypto.randomUUID().replace(/-/g, ''));
+
+// middleware for auth
+express.middleware((request) => {
+    const { userJwtToken } = request.body;
+    const isConsole = request.path.includes('/console');
+
+    if (isConsole && !userJwtToken) {
+        throw Error('No JWT Token found, aborting the requests.');
+    }
+});
+
+// directs
+express.get('/', (request, response) => response.send(request.method));
+express.post('/', (request, response) => response.send(request.method));
+express.put('/', (request, response) => response.send(request.method));
+express.patch('/', (request, response) => response.send(request.method));
+express.delete('/', (request, response) => response.send(request.method));
+express.options('/', (request, response) => response.send(request.method));
+
+// with router
+router.get('/empty', (request, response) => response.empty());
+router.get('/', (request, response) => response.json(request.body));
+router.post('/:user', (request, response) =>
+    response.send(request.params.user),
+);
+router.post('/:user/:transaction', (request, response) => {
+    response.json({
+        user: request.params.user,
+        transaction: request.params.transaction,
+    });
+});
+
+express.use('/router', router);
+
+// get method only for testing `Cannot [method] '[path]'`
+express.get('/get', (request, response) => {
+    // this route isn't called while testing.
+    // response.send('get');
+});
+
+// all
+express.all('/all', (_, response) => response.send('same on all'));
+
+// auth with a hooked middleware
+express.get('/console', (_, response) => response.send('console'));
+
+// use injected repo for test
+const injectionRouter = new AppExpress.Router();
+injectionRouter.get('/', (request, response) => {
+    const repository = request.retrieve(LoremIpsumRepository, 'one');
+    response.send(repository.get());
+});
+
+injectionRouter.get('/error', (request, response) => {
+    const repository = request.retrieve(LoremIpsumRepository);
+    response.send(repository.get());
+});
+
+express.use('/lorem_ipsum', injectionRouter);
+
+// Appwrite Function Entrypoint!
+export default async (context) => await express.attach(context);

--- a/source/tests/entrypoint/index.js
+++ b/source/tests/entrypoint/index.js
@@ -54,7 +54,7 @@ router.post('/:user/:transaction', (request, response) => {
 express.use('/router', router);
 
 // get method only for testing `Cannot [method] '[path]'`
-express.get('/get', (request, response) => {
+express.get('/get', (_, __) => {
     // this route isn't called while testing.
     // response.send('get');
 });

--- a/source/tests/test.js
+++ b/source/tests/test.js
@@ -1,0 +1,148 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import index from './entrypoint/index.js';
+import { createContext } from './utils/context.js';
+
+describe('Direct requests to all supported methods', () => {
+    ['get', 'post', 'put', 'patch', 'delete', 'options'].forEach((method) => {
+        it(`should return the ${method} method in response body`, async () => {
+            const context = createContext({ method: method });
+            const response = await index(context);
+            assert.strictEqual(response.body, method);
+        });
+    });
+});
+
+describe('Uniform response on `all` endpoint across methods', () => {
+    ['get', 'post', 'put', 'patch', 'delete', 'options'].forEach((method) => {
+        it(`should receive 'same on all' response using ${method} method`, async () => {
+            const context = createContext({ path: '/all', method: method });
+            const response = await index(context);
+            assert.strictEqual(response.body, 'same on all');
+        });
+    });
+});
+
+describe('Responses from router-handled endpoints', () => {
+    it('should match the body with a get request to /router', async () => {
+        const body = { key: 'value' };
+        const context = createContext({ path: '/router', body });
+        const response = await index(context);
+        assert.deepStrictEqual(response, body);
+    });
+
+    it('should return an empty response for POST /router/empty', async () => {
+        const context = createContext({ path: `/router/empty` });
+        const response = await index(context);
+        assert.strictEqual(response, '');
+    });
+
+    it('should return the user ID for POST /router/:user', async () => {
+        const user = 'cad7eee9bb524d6dac9b73b6e9f2c8c6';
+        const context = createContext({
+            method: 'post',
+            path: `/router/${user}`,
+        });
+        const response = await index(context);
+        assert.strictEqual(response.body, user);
+    });
+
+    it('should return a structured response for POST /router/:user/:transaction', async () => {
+        const user = 'cad7eee9bb524d6dac9b73b6e9f2c8c6';
+        const transaction = '0835fbe57f3540b3badd10fc31466fd9';
+        const context = createContext({
+            method: 'post',
+            path: `/router/${user}/${transaction}`,
+        });
+        const response = await index(context);
+        assert.deepStrictEqual(response, { user, transaction });
+    });
+});
+
+describe('Handling invalid method requests to specific endpoints', () => {
+    ['post', 'put', 'patch', 'delete', 'options'].forEach((method) => {
+        it(`should return an error when using ${method.toUpperCase()} on '/get' endpoint`, async () => {
+            const context = createContext({ path: '/get', method: method });
+            const response = await index(context);
+            assert.strictEqual(
+                response.body,
+                `Cannot ${method.toUpperCase()} '/get'.`,
+            );
+        });
+    });
+});
+
+describe('Response for non-existing endpoints', () => {
+    ['get', 'post', 'put', 'patch', 'delete', 'options'].forEach((method) => {
+        it(`should return an error for ${method.toUpperCase()} request to '/void'`, async () => {
+            const context = createContext({ path: '/void', method: method });
+            const response = await index(context);
+            assert.strictEqual(
+                response.body,
+                `Cannot ${method.toUpperCase()} '/void'.`,
+            );
+        });
+    });
+});
+
+describe('Internal server error handling', () => {
+    it('should return a 500 status code for invalid returns', async () => {
+        const context = createContext({ path: '/get', method: 'get' });
+        const response = await index(context);
+        assert.strictEqual(response.statusCode, 500);
+    });
+});
+
+describe('Middleware error handling', () => {
+    it('should throw an error when no JWT Token is found', async () => {
+        const context = createContext({ path: '/console', method: 'get' });
+        try {
+            await index(context);
+        } catch (error) {
+            assert.strictEqual(
+                error.message,
+                'No JWT Token found, aborting the requests.',
+            );
+        }
+    });
+
+    it("should return 'console' in the response body when a JWT Token is provided", async () => {
+        const context = createContext({
+            path: '/console',
+            method: 'get',
+            body: {
+                userJwtToken:
+                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+            },
+        });
+        const response = await index(context);
+        assert.strictEqual(response.body, 'console');
+    });
+});
+
+describe('Injected dependency validation', () => {
+    it('should return lorem ipsum text', async () => {
+        const context = createContext({ path: '/lorem_ipsum', method: 'get' });
+        const response = await index(context);
+        assert.strictEqual(
+            response.body,
+            'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        );
+    });
+
+    it('should throw an error when dependencies is not found', async () => {
+        const context = createContext({
+            path: '/lorem_ipsum/error',
+            method: 'get',
+        });
+        try {
+            await index(context);
+        } catch (error) {
+            assert.strictEqual(
+                error.message,
+                `No instance found for 'LoremIpsumRepository'.`,
+            );
+        }
+    });
+});

--- a/source/tests/utils/context.js
+++ b/source/tests/utils/context.js
@@ -1,0 +1,32 @@
+/**
+ * Creates a context with predefined HTTP request and response handlers.
+ *
+ * @param {string} method='get' - HTTP method of the request.
+ * @param {string} path='/' - Path for the HTTP request.
+ * @param {Object} headers={} - Headers for the HTTP request.
+ * @param {{}} requestOptions - Additional properties to be included in the request.
+ * @returns {Object} Returns a context object containing request data, response handlers, and logging functions.
+ */
+export const createContext = ({
+    method = 'get',
+    path = '/',
+    headers = {},
+    ...requestOptions
+} = {}) => {
+    return {
+        req: {
+            method,
+            path,
+            headers,
+            ...requestOptions,
+        },
+        res: {
+            empty: () => '',
+            redirect: (url) => url,
+            json: (object) => object,
+            send: (body, statusCode) => ({ body, statusCode }),
+        },
+        log: (_) => '', // empty for the sake of testing
+        error: (_) => '', // empty for the sake of testing
+    };
+};

--- a/source/tests/utils/context.js
+++ b/source/tests/utils/context.js
@@ -20,11 +20,20 @@ export const createContext = ({
             headers,
             ...requestOptions,
         },
+
+        /**
+         * As per [server.js](https://github.com/open-runtimes/open-runtimes/blob/16bf063b60f1f2a150b6caa9afdd2d1786e7ca35/runtimes/node-18.0/src/server.js#L87C9-L106C11),
+         * all methods except `empty()` support `statusCode` & `headers` but they are managed internally.
+         */
         res: {
             empty: () => '',
             redirect: (url) => url,
             json: (object) => object,
-            send: (body, statusCode) => ({ body, statusCode }),
+            send: (body, statusCode, headers) => ({
+                body,
+                statusCode,
+                headers,
+            }),
         },
         log: (_) => '', // empty for the sake of testing
         error: (_) => '', // empty for the sake of testing

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -16,11 +16,6 @@
  */
 
 /**
- * @typedef {function(request: AppExpressRequest, log: function(string): void, error: function(string): void): any} MiddlewareHandler
- * @description Represents a function that handles requests. It accepts a request object, and two logging functions (for logging and errors).
- */
-
-/**
  * @typedef {Map<string, {type: Function, instance: any}>} InjectionRegistry
  * @description Manages and tracks dependency injections, mapping unique identifiers to their respective instances and types.
  */

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -6,11 +6,41 @@
  *
  * @property {Object} req - The request object, encapsulating details such as headers, method, and body.
  * @property {Object} res - The response object, used for sending data back to the client.
- * @property {function(string): void} log - Function to log debug messages.
- * @property {function(string): void} error - Function to log error messages.
+ * @property {function(message: string): void} log - Function to log debug messages.
+ * @property {function(error: string): void} error - Function to log error messages.
  */
 
 /**
- * @typedef {function(req: AppExpressRequest, res: AppExpressResponse, log: function(string): void, error: function(string): void): Promise<any>} RequestHandler
+ * @typedef {function(req: AppExpressRequest, res: AppExpressResponse, log: function(string): void, error: function(string): void): any} RequestHandler
  * @description Represents a function that handles requests. It accepts a request object, a response object, and two logging functions (for logging and errors).
  */
+
+/**
+ * @typedef {Object} RequestMethods
+ * @description Stores Maps of URL paths to handler functions for different HTTP request methods.
+ *
+ * @property {Map<string, RequestHandler>} get - Map for `GET` request handlers.
+ * @property {Map<string, RequestHandler>} post - Map for `POST` request handlers.
+ * @property {Map<string, RequestHandler>} put - Map for `PUT` request handlers.
+ * @property {Map<string, RequestHandler>} patch - Map for `PATCH` request handlers.
+ * @property {Map<string, RequestHandler>} delete - Map for `DELETE` request handlers.
+ * @property {Map<string, RequestHandler>} options - Map for `OPTIONS` request handlers.
+ * @property {Map<string, RequestHandler>} all - Map for handlers that apply to `ALL` request methods.
+ */
+
+/**
+ * Creates and returns a new set of request method maps.
+ *
+ * @returns {RequestMethods} A new instance of request method maps for routing.
+ */
+export function requestMethods() {
+    return {
+        get: new Map(),
+        post: new Map(),
+        put: new Map(),
+        patch: new Map(),
+        delete: new Map(),
+        options: new Map(),
+        all: new Map()
+    };
+}

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -41,6 +41,6 @@ export function requestMethods() {
         patch: new Map(),
         delete: new Map(),
         options: new Map(),
-        all: new Map()
+        all: new Map(),
     };
 }

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -11,8 +11,13 @@
  */
 
 /**
- * @typedef {function(req: AppExpressRequest, res: AppExpressResponse, log: function(string): void, error: function(string): void): any} RequestHandler
+ * @typedef {function(request: AppExpressRequest, response: AppExpressResponse, log: function(string): void, error: function(string): void): any} RequestHandler
  * @description Represents a function that handles requests. It accepts a request object, a response object, and two logging functions (for logging and errors).
+ */
+
+/**
+ * @typedef {function(request: AppExpressRequest, log: function(string): void, error: function(string): void): any} MiddlewareHandler
+ * @description Represents a function that handles requests. It accepts a request object, and two logging functions (for logging and errors).
  */
 
 /**

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -21,6 +21,11 @@
  */
 
 /**
+ * @typedef {Map<string, {type: Function, instance: any}>} InjectionRegistry
+ * @description Manages and tracks dependency injections, mapping unique identifiers to their respective instances and types.
+ */
+
+/**
  * @typedef {Object} RequestMethods
  * @description Stores Maps of URL paths to handler functions for different HTTP request methods.
  *

--- a/source/types/request.js
+++ b/source/types/request.js
@@ -40,9 +40,9 @@ class AppExpressRequest {
     }
 
     /**
-     * Gets the headers of the request if present.
+     * Gets the headers of the request.
      *
-     * @returns {Object|undefined} The  request headers.
+     * @returns {Object<string, any>} The request headers.
      */
     get headers() {
         return this._request.headers;
@@ -51,7 +51,7 @@ class AppExpressRequest {
     /**
      * Get the request scheme (http or https).
      *
-     * @returns {Object|undefined} The scheme of the request.
+     * @returns {string} The scheme of the request.
      */
     get scheme() {
         return this._request.scheme;
@@ -60,7 +60,7 @@ class AppExpressRequest {
     /**
      * Get the request method (GET, POST, etc.)
      *
-     * @returns {string|undefined} The raw request body or undefined if not set.
+     * @returns {string} The raw request body.
      */
     get method() {
         return this._request.method.toLowerCase();
@@ -69,7 +69,7 @@ class AppExpressRequest {
     /**
      * Get the url of the request.
      *
-     * @returns {string|undefined} The full URL.
+     * @returns {string} The full URL.
      */
     get url() {
         return this._request.url;
@@ -78,7 +78,7 @@ class AppExpressRequest {
     /**
      * Get the hostname of the URL.
      *
-     * @returns {string|undefined} The URL host.
+     * @returns {string} The URL host.
      */
     get host() {
         return this._request.host;
@@ -87,17 +87,16 @@ class AppExpressRequest {
     /**
      * Get the port from the URL.
      *
-     * @returns {number|undefined} The URL port.
+     * @returns {number} The URL port.
      */
     get port() {
-        const port = this._request.port;
-        return port ? parseInt(port, 10) : undefined;
+        return parseInt(this._request.port, 10);
     }
 
     /**
      * Get the path part of the URL.
      *
-     * @returns {string|undefined} The URL path.
+     * @returns {string} The URL path.
      */
     get path() {
         return this._request.path;
@@ -106,7 +105,7 @@ class AppExpressRequest {
     /**
      * Get the raw query params string from the URL.
      *
-     * @returns {string|undefined} The query string.
+     * @returns {string} The query string.
      */
     get queryString() {
         return this._request.queryString;
@@ -118,7 +117,7 @@ class AppExpressRequest {
      * @returns {Object<string, any>} The parsed params.
      */
     get params() {
-        return this._request.params;
+        return this._request.params ?? {};
     }
 
     /**
@@ -144,7 +143,7 @@ class AppExpressRequest {
      *
      * Can be `event`, `http` or `scheduled`.
      *
-     * @returns {'event'|'http'|'scheduled'|undefined} The trigger type.
+     * @returns {'event'|'http'|'scheduled'} The trigger type.
      */
     get triggeredType() {
         return this.headers['x-appwrite-trigger'];

--- a/source/types/request.js
+++ b/source/types/request.js
@@ -183,25 +183,20 @@ class AppExpressRequest {
      * @throws {Error} - If no instance is found or if multiple instances are found without an identifier.
      */
     retrieve(type, identifier = '') {
-        const key = identifier ? `${type.name}:${identifier}` : type.name;
-        const found = this._request.dependencies.find(
-            (injection) =>
-                (injection.id
-                    ? `${injection.type.name}:${injection.id}`
-                    : injection.type.name) === key,
-        );
+        const objectName = type.name;
+        const key = identifier ? `${objectName}:${identifier}` : objectName;
 
-        if (!found) {
+        if (!this._request.dependencies.has(key)) {
             if (identifier) {
                 throw new Error(
-                    `No instance found for '${type.name}' with identifier '${identifier}'.`,
+                    `No instance found for '${objectName}' with identifier '${identifier}'.`,
                 );
             } else {
-                throw new Error(`No instance found for '${type.name}'.`);
+                throw new Error(`No instance found for '${objectName}'.`);
             }
         }
 
-        return found.instance;
+        return this._request.dependencies.get(key).instance;
     }
 
     /**

--- a/source/types/response.js
+++ b/source/types/response.js
@@ -100,7 +100,7 @@ class AppExpressResponse {
     /**
      * Wrap the return value for safety.
      *
-     * This is helpful even if the developer ever forgets to use `return` in the `RequestHandler`
+     * This is helpful if the developer ever forgets to use `return` in the `RequestHandler`.
      *
      * @param {any} data - The data to wrap for safety.
      * @returns {data} - The same data but safely wrapped in a dynamic variable.

--- a/source/types/response.js
+++ b/source/types/response.js
@@ -13,6 +13,39 @@ class AppExpressResponse {
     constructor(context) {
         this._context = context;
         this._response = context.res;
+
+        /** @type {Object<string, string|number>} */
+        this._customHeaders = {};
+    }
+
+    /**
+     * Add custom headers to send back to the source.
+     *
+     * **Note**: If you call `setHeaders` multiple times for a request,
+     * remember that all the headers are combined when sent back to the source.
+     *
+     * **Also Note**: A duplicate header will be overridden with the value from the last call.
+     *
+     * @param {Object<string, string|number>} headers - Custom headers to send back to the source.
+     * @throws {Error} - If the header value is not a string or a number.
+     */
+    setHeaders(headers) {
+        for (const [headerKey, value] of Object.entries(headers)) {
+            if (typeof value !== 'string' && typeof value !== 'number') {
+                throw new Error(
+                    `Custom headers only support values of type string or number. Provided type for key '${headerKey}': ${typeof value}.`,
+                );
+            }
+
+            this._customHeaders[headerKey] = value;
+        }
+    }
+
+    /**
+     * Clears all the headers added via `setHeaders`.
+     */
+    clearHeaders() {
+        this._customHeaders = {};
     }
 
     /**
@@ -52,6 +85,7 @@ class AppExpressResponse {
         return this.#wrapReturnForSafety(
             this._response.send(string, statusCode, {
                 'content-type': contentType,
+                ...this._customHeaders,
             }),
         );
     }

--- a/source/types/response.js
+++ b/source/types/response.js
@@ -77,13 +77,13 @@ class AppExpressResponse {
     /**
      * Send a response with a specific content type and status code.
      *
-     * @param {string} string - The response body to send.
+     * @param {any} content - The response body to send.
      * @param {number} statusCode=200 - The HTTP status code.
      * @param {string} contentType='text/plain' - The content type of the response.
      */
-    send(string, statusCode = 200, contentType = 'text/plain') {
+    send(content, statusCode = 200, contentType = 'text/plain') {
         return this.#wrapReturnForSafety(
-            this._response.send(string, statusCode, {
+            this._response.send(content, statusCode, {
                 'content-type': contentType,
                 ...this._customHeaders,
             }),
@@ -109,26 +109,58 @@ class AppExpressResponse {
      */
     async htmlFromFile(filePath, statusCode = 200) {
         try {
-            const fullPath = this._response.views
-                ? `${this._response.views}/${filePath}`
-                : `${filePath}`;
-
-            /**
-             * afaik, the current directory is always `server`.\
-             * See [here](https://github.com/open-runtimes/open-runtimes/blob/16bf063b60f1f2a150b6caa9afdd2d1786e7ca35/runtimes/node-18.0/src/server.js#L6) how the exact path is derived.
-             *
-             * @type {string}
-             */
-            const usablePath = path.join(
-                process.cwd(),
-                `./src/function/${fullPath}`,
-            );
-            const htmlContent = await fs.readFile(usablePath, 'utf8');
+            const htmlContent = await this.readFile(filePath, 'utf8');
             return this.html(htmlContent, statusCode);
         } catch (error) {
             this._context.error(`Failed to read HTML file: ${error}`);
             return this.send('Internal Server Error', 500, 'text/plain');
         }
+    }
+
+    /**
+     * Reads a file asynchronously and returns its contents as a Buffer.
+     *
+     * @param {string} path - The path to the file relative to a base path.
+     * @param {string|null} [encoding=null] - The encoding to use. If null, the function returns a Buffer.
+     * @returns {Promise<string|Buffer|null>} - A promise that resolves with the file contents as a Buffer or as a string or null if there was an error.
+     */
+    async readFile(path, encoding = null) {
+        const options = {};
+
+        const filePath = this.#buildFilePath(path);
+        const usablePath = this.#basePath(filePath);
+
+        if (encoding) options.encoding = encoding;
+
+        try {
+            return await fs.readFile(usablePath, options);
+        } catch (error) {
+            this._context.error(`Failed to read file: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * Adds the views directory (if exists) as the correct prefix.
+     *
+     * @param {string} fileName - The name of the file.
+     * @returns {string} The correct path for the given file.
+     */
+    #buildFilePath(fileName) {
+        return this._response.views
+            ? `${this._response.views}/${fileName}`
+            : `${fileName}`;
+    }
+
+    /**
+     * Returns the base path where the function is running on the server.
+     *
+     * See [here](https://github.com/open-runtimes/open-runtimes/blob/16bf063b60f1f2a150b6caa9afdd2d1786e7ca35/runtimes/node-18.0/src/server.js#L6) how the exact path is derived.
+     * @param append='' - Any path to append to the base path
+     * @returns {string} The base path of the function directory.
+     */
+    #basePath(append = '') {
+        return path.join(process.cwd(), `./src/function/${append}`);
     }
 
     /**

--- a/source/types/response.js
+++ b/source/types/response.js
@@ -20,7 +20,7 @@ class AppExpressResponse {
      * typically used when there's no need to send back any data to the source.
      */
     empty() {
-        return this._response.empty();
+        return this.#wrapReturnForSafety(this._response.empty());
     }
 
     /**
@@ -29,7 +29,7 @@ class AppExpressResponse {
      * @param {Object} data - The JSON data to send.
      */
     json(data) {
-        return this._response.json(data);
+        return this.#wrapReturnForSafety(this._response.json(data));
     }
 
     /**
@@ -38,7 +38,7 @@ class AppExpressResponse {
      * @param {string} url - The URL to redirect to.
      */
     redirect(url) {
-        return this._response.redirect(url);
+        return this.#wrapReturnForSafety(this._response.redirect(url));
     }
 
     /**
@@ -49,16 +49,18 @@ class AppExpressResponse {
      * @param {string} contentType='text/plain' - The content type of the response.
      */
     send(string, statusCode = 200, contentType = 'text/plain') {
-        return this._response.send(string, statusCode, {
-            'content-type': contentType,
-        });
+        return this.#wrapReturnForSafety(
+            this._response.send(string, statusCode, {
+                'content-type': contentType,
+            }),
+        );
     }
 
     /**
      * Send an HTML response back to the source which is rendered for the user.
      *
      * @param {string} stringHtml - The HTML string to send.
-     * @param {number} [statusCode=200] - The HTTP status code.
+     * @param {number} statusCode=200 - The HTTP status code.
      */
     html(stringHtml, statusCode = 200) {
         return this.send(stringHtml, statusCode, 'text/html');
@@ -93,6 +95,19 @@ class AppExpressResponse {
             this._context.error(`Failed to read HTML file: ${error}`);
             return this.send('Internal Server Error', 500, 'text/plain');
         }
+    }
+
+    /**
+     * Wrap the return value for safety.
+     *
+     * This is helpful even if the developer ever forgets to use `return` in the `RequestHandler`
+     *
+     * @param {any} data - The data to wrap for safety.
+     * @returns {data} - The same data but safely wrapped in a dynamic variable.
+     */
+    #wrapReturnForSafety(data) {
+        this._response.dynamic = data;
+        return this._response.dynamic;
     }
 }
 


### PR DESCRIPTION
1. This PR adds the ability to use a `Router`, something like -
    ```javascript
    const appExpress = new AppExpress();
    const router = new AppExpress.Router();
    
    router.get('/sub', (...) {});
    router.post('/sub', (...) {});
    router.patch('/sub', (...) {});
    
    appExpress.use('/', router);
    ```

2. Additional changes include perf. side improvements by replacing `Array` implementations with `Map` for fast access.
3. Implement `tests`, add a GitHub Workflow for PRs for the same
4. Middleware registry is now via `appExpress.middleware(...)` and not `appExpress.use(...)`
5. Middlewares now run before finding any routes and can also **return responses** now