### PR TITLE
Feat: Add HTTP Compression

### DIFF
--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -851,7 +851,7 @@ class AppExpress {
     #updateDynamic(dynamic, headers, body) {
         dynamic.body = body;
         dynamic.headers = headers;
-        headers['content-length'] = body.length;
+        dynamic.headers['content-length'] = body.length;
     }
 
     /**

--- a/source/tests/test.js
+++ b/source/tests/test.js
@@ -7,6 +7,8 @@ import { describe, it } from 'node:test';
 import index from './src/function/index.js';
 import { createContext } from './utils/context.js';
 
+const publicDir = './src/function/public';
+
 describe('Direct requests to all supported methods', () => {
     ['get', 'post', 'put', 'patch', 'delete', 'options'].forEach((method) => {
         it(`should return the ${method} method in response body`, async () => {
@@ -249,8 +251,6 @@ describe('Render partials contents on supported engines', () => {
 });
 
 describe('Public static resource handling', () => {
-    const publicDir = './src/function/public';
-
     it('should return the contents of ads.txt', async () => {
         const adsTxt = `${publicDir}/ads.txt`;
         const adsTxtContent = fs.readFileSync(adsTxt, 'utf8');
@@ -329,7 +329,6 @@ describe('Multiple returns error validation', () => {
 
 describe('HTTP compression validation', () => {
     it(`should return a compressed buffer for ads.txt using GZIP`, async () => {
-        const publicDir = './src/function/public';
         const favicon = `${publicDir}/ads.txt`;
         const faviconContent = fs.readFileSync(favicon);
         const compressedContent = zlib.gzipSync(faviconContent, { level: 6 });
@@ -344,7 +343,6 @@ describe('HTTP compression validation', () => {
     });
 
     it(`should return a compressed buffer for favicon.ico using Brotli`, async () => {
-        const publicDir = './src/function/public';
         const favicon = `${publicDir}/favicon.ico`;
         const faviconContent = fs.readFileSync(favicon);
         const compressedContent = zlib.brotliCompressSync(faviconContent, {
@@ -361,7 +359,6 @@ describe('HTTP compression validation', () => {
     });
 
     it(`should return a compressed buffer for robots.txt using Deflate`, async () => {
-        const publicDir = './src/function/public';
         const favicon = `${publicDir}/robots.txt`;
         const faviconContent = fs.readFileSync(favicon);
         const compressedContent = zlib.deflateSync(faviconContent, {

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -6,18 +6,26 @@
  *
  * @property {Object} req - The request object, encapsulating details such as headers, method, and body.
  * @property {Object} res - The response object, used for sending data back to the client.
- * @property {function(message: string): void} log - Function to log debug messages.
- * @property {function(error: string): void} error - Function to log error messages.
+ * @property {(message: string) => void} log - Function to log debug messages.
+ * @property {(error: string) => void} error - Function to log error messages.
  */
 
 /**
- * @typedef {function(request: AppExpressRequest, response: AppExpressResponse, log: function(string): void, error: function(string): void): any} RequestHandler
+ * @typedef {(request: AppExpressRequest, response: AppExpressResponse, log: function(string): void, error: function(string): void) => any} RequestHandler
  * @description Represents a function that handles requests. It accepts a request object, a response object, and two logging functions (for logging and errors).
  */
 
 /**
  * @typedef {Map<string, {type: Function, instance: any}>} InjectionRegistry
  * @description Manages and tracks dependency injections, mapping unique identifiers to their respective instances and types.
+ */
+
+/**
+ * @typedef {Object} CompressionHandler
+ * @description Represents a function that allows a user to use a custom compression for HTTP responses.
+ *
+ * @property {Set<string>} encodings - The list of encodings that the handler supports.
+ * @property {(buffer: Buffer) => Promise<Buffer>|Buffer} compress - Function to compress data.
  */
 
 /**
@@ -54,3 +62,23 @@ export function requestMethods() {
         all: new Map(),
     };
 }
+
+/**
+ * Returns a function that checks if a given content type is compressible.
+ *
+ * @returns {boolean} Returns true if the content type is compressible.
+ */
+export const isCompressible = (contentType) => {
+    const contentTypePatterns = [
+        /^text\/(html|css|plain|xml|x-component|javascript)$/i,
+        /^application\/(x-javascript|javascript|json|manifest\+json|vnd\.api\+json|xml|xhtml\+xml|rss\+xml|atom\+xml|vnd\.ms-fontobject|x-font-ttf|x-font-opentype|x-font-truetype)$/i,
+        /^image\/(svg\+xml|x-icon|vnd\.microsoft\.icon)$/i,
+        /^font\/(ttf|eot|otf|opentype)$/i,
+    ];
+
+    for (const pattern of contentTypePatterns) {
+        if (pattern.test(contentType)) return true;
+    }
+
+    return false;
+};


### PR DESCRIPTION
This PR adds support for HTTP Compression for faster data transfer!
There are 3 default compressions used which are provided by the `zlib` i.e. `br`, `gzip`, `deflate` in the same order for perf.

Additionally, a user can also provide a custom compression handler if the client supports it.
Example -
```javascript
import zstd from '@mongodb-js/zstd';

express.compression({
  encodings: new Set(['zstd']),
  compress: async (buffer) =>  await zstd.compress(buffer, 9);  // don't go over 20!
});
```

---
Supported compressible content types -
```javascript
const contentTypePatterns = [
  /^text\/(html|css|plain|xml|x-component|javascript)$/i,
  /^application\/(x-javascript|javascript|json|manifest\+json|vnd\.api\+json|xml|xhtml\+xml|rss\+xml|atom\+xml|vnd\.ms-fontobject|x-font-ttf|x-font-opentype|x-font-truetype)$/i,
  /^image\/(svg\+xml|x-icon|vnd\.microsoft\.icon)$/i,
  /^font\/(ttf|eot|otf|opentype)$/i,
];
```