### PR TITLE
Improved Middleware

### DIFF
--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -162,8 +162,7 @@ class AppExpress {
 
     constructor() {
         this.middleware({
-            outgoing: async (_, interceptor) => {
-                await this.#compress(interceptor);
+            outgoing: (_, interceptor) => {
                 this.#addPoweredByHeader(interceptor);
             },
         });
@@ -714,8 +713,8 @@ class AppExpress {
 
             try {
                 /**
-                 * `await` the body because it `could` be a promise
-                 * that resolves to a html string for rendering or a buffer.
+                 * `await` the body because it `could` be a promise that
+                 * resolves to a html string for rendering content or a buffer.
                  */
                 result.body = await result.body;
 
@@ -727,6 +726,9 @@ class AppExpress {
                         this.#context.error,
                     );
                 }
+
+                // compress at the very end!
+                await this.#compress(result);
 
                 return result;
             } catch (error) {

--- a/source/tests/src/function/index.js
+++ b/source/tests/src/function/index.js
@@ -123,6 +123,13 @@ express.middleware({
     },
 });
 
+// override body content
+express.middleware({
+    outgoing: (request, interceptor) => {
+        if (request.path === '/body_override') interceptor.body = 'outgoing';
+    },
+});
+
 // directs
 express.get('/', (request, response) => response.send(request.method));
 express.post('/', (request, response) => response.send(request.method));
@@ -207,6 +214,7 @@ express.get('/error/multi-return', (_, response) => {
 });
 
 express.get('/outgoing', (_, res) => res.empty());
+express.get('/body_override', (_, res) => res.empty());
 express.get('/cookies', (_, res) => {
     res.setHeaders({ cookie: crypto.randomUUID() });
     res.empty();

--- a/source/tests/src/function/index.js
+++ b/source/tests/src/function/index.js
@@ -106,6 +106,23 @@ express.middleware((request, response) => {
     }
 });
 
+// intercepting response
+express.middleware({
+    outgoing: (_, interceptor) => {
+        interceptor.headers['X-Server-Powered-By'] = 'Appwrite x Swoole';
+    },
+});
+
+// hard cookie remover
+express.middleware({
+    incoming: (request) => {
+        if (request.path === '/cookies') delete request.headers.cookie;
+    },
+    outgoing: (request, interceptor) => {
+        if (request.path === '/cookies') delete interceptor.headers.cookie;
+    },
+});
+
 // directs
 express.get('/', (request, response) => response.send(request.method));
 express.post('/', (request, response) => response.send(request.method));
@@ -187,6 +204,12 @@ express.get('/engines/article', (request, response) => {
 express.get('/error/multi-return', (_, response) => {
     response.send('ok');
     response.send('ok');
+});
+
+express.get('/outgoing', (_, res) => res.empty());
+express.get('/cookies', (_, res) => {
+    res.setHeaders({ cookie: crypto.randomUUID() });
+    res.empty();
 });
 
 // Appwrite Function Entrypoint!

--- a/source/tests/test.js
+++ b/source/tests/test.js
@@ -178,7 +178,7 @@ describe('Custom headers validation', () => {
     });
 
     it('should only return the default header', async () => {
-        const expected = { length: 2, type: 'text/plain' };
+        const expected = { length: 3, type: 'text/plain' };
         const context = createContext({
             path: `/headers/clear`,
         });
@@ -372,5 +372,31 @@ describe('HTTP compression validation', () => {
 
         const { body } = await index(context);
         assert.deepStrictEqual(body, compressedContent);
+    });
+});
+
+describe('Extended middleware validation', () => {
+    it(`should return a header added by the middleware outgoing handler`, async () => {
+        const expected = {
+            'X-Powered-By': 'AppExpress',
+            'X-Server-Powered-By': 'Appwrite x Swoole',
+        };
+
+        const context = createContext({
+            path: '/outgoing',
+        });
+
+        const { headers } = await index(context);
+        assert.deepStrictEqual(headers, expected);
+    });
+
+    it(`should remove cookies from request an response`, async () => {
+        const context = createContext({
+            path: '/cookies',
+            headers: { cookie: crypto.randomUUID() },
+        });
+
+        const { headers } = await index(context);
+        assert.strictEqual(headers.cookie, undefined);
     });
 });

--- a/source/tests/test.js
+++ b/source/tests/test.js
@@ -399,4 +399,13 @@ describe('Extended middleware validation', () => {
         const { headers } = await index(context);
         assert.strictEqual(headers.cookie, undefined);
     });
+
+    it(`should return a body updated by the middleware outgoing handler`, async () => {
+        const context = createContext({
+            path: '/body_override',
+        });
+
+        const { body } = await index(context);
+        assert.strictEqual(body, 'outgoing');
+    });
 });

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -16,6 +16,20 @@
  */
 
 /**
+ * @typedef {Object} ResponseInterceptor
+ * @description Represents a function that allows intercepting, modifying or updating responses.
+ *
+ * @property {Buffer|string} body - The processed response body.
+ * @property {number} statusCode - The statusCode of the response.
+ * @property {Object<string, string|number>} headers - The headers added to the response.
+ */
+
+/**
+ * @typedef {(request: AppExpressRequest, body: ResponseInterceptor, log: function(string): void, error: function(string): void) => void} ResponseHandler
+ * @description Represents a function that intercepts or modifies or updates responses. It accepts a request object, a response interceptor object, and two logging functions (for logging and errors).
+ */
+
+/**
  * @typedef {Map<string, {type: Function, instance: any}>} InjectionRegistry
  * @description Manages and tracks dependency injections, mapping unique identifiers to their respective instances and types.
  */

--- a/source/types/misc.js
+++ b/source/types/misc.js
@@ -19,7 +19,8 @@
  * @typedef {Object} ResponseInterceptor
  * @description Represents a function that allows intercepting, modifying or updating responses.
  *
- * @property {Buffer|string} body - The processed response body.
+ * @property {string|Buffer|object} body - The processed response body.\
+ * **Note**: The contents of the body are not compressed yet.
  * @property {number} statusCode - The statusCode of the response.
  * @property {Object<string, string|number>} headers - The headers added to the response.
  */

--- a/source/types/response.js
+++ b/source/types/response.js
@@ -64,7 +64,9 @@ class AppExpressResponse {
      * typically used when there's no need to send back any data to the source.
      */
     empty() {
-        this.#wrapReturnForSource(this.#response.empty());
+        this.#wrapReturnForSource(
+            this.#response.send('', 204, this.#customHeaders),
+        );
     }
 
     /**
@@ -252,20 +254,18 @@ class AppExpressResponse {
             ...this.#customHeaders,
         });
 
-        this.#wrapReturnForSource(promiseDataType, true);
+        this.#wrapReturnForSource(promiseDataType);
     }
 
     /**
      * Wrap the return value for source.
      *
      * @param {any} data - The data to wrap for safety.
-     * @param {boolean} promise=false - Whether the provided data is a `Promise`.
      */
-    #wrapReturnForSource(data, promise = false) {
+    #wrapReturnForSource(data) {
         this.#checkIfAlreadyPrepared();
 
         this.#response.dynamic = data;
-        this.#response.promise = promise;
     }
 
     /**


### PR DESCRIPTION
Current middleware behaviour only allows to add a interceptor for `incoming` requests. This PR adds support to intercept the `outgoing` responses too.

The middleware behaviour is compatible with the previous implementation.

Example -
Remove cookies from request & response.
```javascript
appExpress.middleware({
  incoming: (req) => delete req.headers.cookie,
  outgoing: (_, interceptor) => delete interceptor.headers.cookie,
});
```

---
The `interceptor` contains the processed `body` which could be a `String` or a `Buffer`, `statusCode` & the `headers`.