### PR TITLE
Multiple Extensions for a View Engine

### DIFF
--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -209,28 +209,33 @@ class AppExpress {
      * })
      * ```
      *
-     * @param {string} ext - The file extension for the engine.
+     * @param {string|string[]} ext - The file extension[s] for the engine.
      * @param {any} engine - The view engine that will be used for rendering content.
      */
     engine(ext, engine) {
-        // `hbs`, `ejs`, `pug` have this variable,
-        // that is handled by express internally.
-        if (engine.hasOwnProperty('__express')) {
-            this.#engine.set(ext, engine.__express);
-        } else if (typeof engine === 'function') {
-            // `express-hbs` uses 4 params,
-            // but adjusts to 3 dynamically.
-            if (engine.length >= 3) this.#engine.set(ext, engine);
-            else {
-                throw new Error(
-                    `Your custom engine function must have exactly 3 methods (filePath, options, callback(error, content). Current length: ${engine.length}`,
-                );
-            }
-        } else {
+        // perform a quick validation!
+        if (!Array.isArray(ext) && typeof ext !== 'string') {
             throw new Error(
-                'This view engine may be unsupported as it seems to be missing the function required to render content.',
+                'The extension must be a string or an array of strings.',
             );
         }
+
+        // construct an array for looping around...
+        const extensions = Array.isArray(ext) ? ext : [ext];
+
+        extensions.forEach((extension) => {
+            // `hbs`, `ejs`, `pug` have this variable,
+            // that is handled by express internally.
+            if (engine.hasOwnProperty('__express')) {
+                this.#engine.set(extension, engine.__express);
+            } else if (typeof engine === 'function' && engine.length >= 3) {
+                this.#engine.set(extension, engine);
+            } else {
+                throw new Error(
+                    `Invalid engine: It must either have a '__express' property or be a function with at least 3 parameters. Received function length: ${engine.length}`,
+                );
+            }
+        });
     }
 
     /**

--- a/source/tests/src/function/index.js
+++ b/source/tests/src/function/index.js
@@ -31,17 +31,9 @@ express.static('public', [/^\..*env.*/i]);
 express.engine('ejs', ejs); // ejs
 express.engine('pug', pug); // pub
 
-// hbs
+// hbs, html
 express.engine(
-    'hbs',
-    hbs.express4({
-        partialsDir: path.join(AppExpress.baseDirectory, 'views/partials'),
-    }),
-);
-
-// html x hbs
-express.engine(
-    'html',
+    ['hbs', 'html'],
     hbs.express4({
         partialsDir: path.join(AppExpress.baseDirectory, 'views/partials'),
     }),


### PR DESCRIPTION
A view engine can support multiple file types, example -
1. HBS View Engine supports `.hbs` & `.html` files
2. JSX View Engine supports `.js`, `.jsx` & `.tsx` files

Current implementations requires adding an engine for each extension which can be repetitive, this PR addresses that issue.

---
Previously -
```javascript
express.engine('js', jsx.engine);
express.engine('jsx', jsx.engine);
express.engine('tsx', jsx.engine);
```

New Approach -
```javascript
express.engine(['js', 'jsx', 'tsx'], jsx.engine);
```