### PR TITLE
Override Console Logging

### DIFF
--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -556,6 +556,21 @@ class AppExpress {
     }
 
     /**
+     * Override console logging to avoid seeing below message in executions logs on console -
+     *
+     * ```text
+     * ----------------------------------------------------------------------------
+     * Unsupported logs detected. Use context.log() or context.error() for logging.
+     * ----------------------------------------------------------------------------
+     * ```
+     */
+    #overrideConsoleLogging() {
+        const log = this.#context.log;
+        console.error = this.#context.error;
+        console.log = console.warn = console.info = console.debug = log;
+    }
+
+    /**
      * Handle incoming requests.
      */
     async #handleRequest() {
@@ -899,6 +914,9 @@ class AppExpress {
     async attach(context) {
         // appwrite context.
         this.#context = context;
+
+        // override console logging.
+        this.#overrideConsoleLogging();
 
         // attach AppExpress to Function.
         return await this.#handleRequest();

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itznotabug/appexpress",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "An `express.js` like framework for Appwrite Functions, enabling super-easy navigation!",
   "author": "@itznotabug",
   "type": "module",


### PR DESCRIPTION
This would effectively resolve #34.

---
**Note**: The warnings produced by `Node` during build or some other call to `console.log` before `AppExpress` takes over will still show the warning mentioned in the issue.