### PR TITLE
Feat: Use `index.html` as the default view

### DIFF
--- a/.github/workflows/function.yaml
+++ b/.github/workflows/function.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/source.yaml
+++ b/.github/workflows/source.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: npm install

--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -230,15 +230,15 @@ class AppExpress {
         const extensions = Array.isArray(ext) ? ext : [ext];
 
         extensions.forEach((extension) => {
-            // `hbs`, `ejs`, `pug` have this variable,
+            // `ejs` & `pug` have this variable,
             // that is handled by express internally.
             if (engine.hasOwnProperty('__express')) {
                 this.#engine.set(extension, engine.__express);
-            } else if (typeof engine === 'function' && engine.length >= 3) {
+            } else if (typeof engine === 'function') {
                 this.#engine.set(extension, engine);
             } else {
                 throw new Error(
-                    `Invalid engine: It must either have a '__express' property or be a function with at least 3 parameters. Received function length: ${engine.length}`,
+                    `Invalid engine: It must either have a '__express' property or be a function.`,
                 );
             }
         });

--- a/source/appexpress.js
+++ b/source/appexpress.js
@@ -159,6 +159,9 @@ class AppExpress {
     /** @type string[] */
     #cleanUrlExtensions = [];
 
+    /** @type boolean */
+    #indexAsDefault = false;
+
     /**
      * The base directory inside the docker container where the function is run.\
      * See [here](https://github.com/open-runtimes/open-runtimes/blob/main/runtimes/node/versions/latest/src/server.js#L5) how the exact path is derived.
@@ -437,6 +440,10 @@ class AppExpress {
             const filesMapping = this.#processDirectory(directory, exclude);
 
             this.middleware((request, response) => {
+                // anything other than `GET` req. method
+                // doesn't make sense on static resources.
+                if (request.method !== 'get') return;
+
                 let requestedFile = filesMapping[request.path];
 
                 // If `clean URLs` and no match found, check with `ext`.
@@ -444,6 +451,13 @@ class AppExpress {
                     requestedFile = this.#cleanUrlExtensions
                         .map((ext) => `${request.path}.${ext}`)
                         .reduce((acc, path) => acc || filesMapping[path], null);
+                }
+
+                // If index fallback is enabled & no file found,
+                // look for an `index.html` in the requested directory.
+                if (!requestedFile && this.#indexAsDefault) {
+                    const indexPath = path.join(request.path, 'index.html');
+                    requestedFile = filesMapping[indexPath];
                 }
 
                 if (requestedFile) {
@@ -475,12 +489,30 @@ class AppExpress {
      *
      * _Note: Only works for files added via {@link AppExpress#static} method._
      *
-     * @example `index` > `index.html`, `contact` > `contact.html`
+     * @example
+     * 1. Navigating to `/faqs` will serve `faqs.html`
+     * 2. Navigating to `/contact` will serve `contact.html`
      *
      * @param {string[]} extensions - List of file extensions (e.g., ['html']) for clean URLs.
      */
     cleanUrls(extensions = []) {
         this.#cleanUrlExtensions = extensions;
+    }
+
+    /**
+     * Enable `index.html` as the default file in directories.\
+     * This feature is **disabled** by default.
+     *
+     * _Note: Only works for files added via {@link AppExpress#static} method._
+     *
+     * @example
+     * 1. Navigating to `/` would serve `index.html`
+     * 2. Navigating to `/contact` would serve `contact/index.html`
+     *
+     * @param {boolean} value - Pass a boolean to enable/disable default indexing.
+     */
+    serveIndex(value) {
+        this.#indexAsDefault = value;
     }
 
     /**

--- a/source/package.json
+++ b/source/package.json
@@ -28,7 +28,7 @@
     "ejs": "3.1.10",
     "showdown": "2.1.0",
     "prettier": "3.3.3",
-    "express-hbs": "2.5.0",
+    "express-handlebars": "8.0.1",
     "@itznotabug/appexpress-nocookies": "^0.0.4"
   },
   "keywords": [

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itznotabug/appexpress",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "An `express.js` like framework for Appwrite Functions, enabling super-easy navigation!",
   "author": "@itznotabug",
   "type": "module",

--- a/source/tests/src/function/index.js
+++ b/source/tests/src/function/index.js
@@ -27,6 +27,7 @@ const repositoryOne = new LoremIpsumRepository();
 const repositoryTwo = new LoremIpsumRepository();
 
 express.views('views');
+express.serveIndex(true);
 express.cleanUrls(['html', 'txt']);
 express.static('public', [/^\..*env.*/i]);
 
@@ -118,12 +119,16 @@ express.middleware({
 });
 
 // directs
-express.get('/', (request, response) => response.text(request.method));
-express.post('/', (request, response) => response.text(request.method));
-express.put('/', (request, response) => response.text(request.method));
-express.patch('/', (request, response) => response.text(request.method));
-express.delete('/', (request, response) => response.text(request.method));
-express.options('/', (request, response) => response.text(request.method));
+express.get('/methods', (request, response) => response.text(request.method));
+express.post('/methods', (request, response) => response.text(request.method));
+express.put('/methods', (request, response) => response.text(request.method));
+express.patch('/methods', (request, response) => response.text(request.method));
+express.delete('/methods', (request, response) =>
+    response.text(request.method),
+);
+express.options('/methods', (request, response) =>
+    response.text(request.method),
+);
 
 // with router
 router.get('/empty', (request, response) => response.empty());

--- a/source/tests/src/function/index.js
+++ b/source/tests/src/function/index.js
@@ -1,7 +1,7 @@
 import ejs from 'ejs';
 import pug from 'pug';
-import hbs from 'express-hbs';
 import showdown from 'showdown';
+import hbs from 'express-handlebars';
 
 import fs from 'fs';
 import path from 'path';
@@ -37,7 +37,9 @@ express.engine('pug', pug); // pub
 // hbs, html
 express.engine(
     ['hbs', 'html'],
-    hbs.express4({
+    hbs.engine({
+        extname: 'hbs',
+        defaultLayout: false,
         partialsDir: path.join(AppExpress.baseDirectory, 'views/partials'),
     }),
 );

--- a/source/tests/src/function/public/contact/enterprise/index.html
+++ b/source/tests/src/function/public/contact/enterprise/index.html
@@ -1,0 +1,1 @@
+<h1>Contact us via at this email address: enterprise@example.com</h1>

--- a/source/tests/src/function/public/contact/enterprise/index.html
+++ b/source/tests/src/function/public/contact/enterprise/index.html
@@ -1,1 +1,1 @@
-<h1>Contact us via at this email address: enterprise@example.com</h1>
+<h1>Contact us at this email address: enterprise@example.com</h1>

--- a/source/tests/src/function/public/contact/index.html
+++ b/source/tests/src/function/public/contact/index.html
@@ -1,1 +1,1 @@
-<h1>Contact us via at this email address: support@example.com</h1>
+<h1>Contact us at this email address: support@example.com</h1>

--- a/source/tests/src/function/public/contact/index.html
+++ b/source/tests/src/function/public/contact/index.html
@@ -1,0 +1,1 @@
+<h1>Contact us via at this email address: support@example.com</h1>

--- a/source/tests/test.js
+++ b/source/tests/test.js
@@ -12,7 +12,10 @@ const publicDir = './src/function/public';
 describe('Direct requests to all supported methods', () => {
     ['get', 'post', 'put', 'patch', 'delete', 'options'].forEach((method) => {
         it(`should return the ${method} method in response body`, async () => {
-            const context = createContext({ method: method });
+            const context = createContext({
+                method: method,
+                path: '/methods',
+            });
             const { body } = await index(context);
             assert.strictEqual(body, method);
         });
@@ -477,5 +480,31 @@ describe('Clean URLs validation', () => {
 
         const { body } = await index(context);
         assert.strictEqual(body, robotsFileContent);
+    });
+});
+
+describe('Index file fallback validation', () => {
+    it(`should return contact/index.html content on requesting just contact path`, async () => {
+        const indexHtml = `${publicDir}/contact/index.html`;
+        const indexContent = fs.readFileSync(indexHtml, 'utf8');
+
+        const context = createContext({
+            path: '/contact',
+        });
+
+        const { body } = await index(context);
+        assert.strictEqual(body, indexContent);
+    });
+
+    it(`should return contact/enterprise/index.html content on requesting just contact/enterprise path`, async () => {
+        const indexHtml = `${publicDir}/contact/enterprise/index.html`;
+        const indexContent = fs.readFileSync(indexHtml, 'utf8');
+
+        const context = createContext({
+            path: '/contact/enterprise',
+        });
+
+        const { body } = await index(context);
+        assert.strictEqual(body, indexContent);
     });
 });


### PR DESCRIPTION
Enable `index.html` as the default file in directories.

---

Example:
1. Navigating to `/` would serve `index.html`
2. Navigating to `/contact` would serve `contact/index.html`
3. Navigating to `/contact/enterprise` would serve `contact/enterprise/index.html`

This is handy when using SSG like tools to build a simple static site.